### PR TITLE
Add authenticated badge indicator to homepage logo cloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,5 +9,6 @@ Interested in adding a brand new provider to Redwood? Head to the [main Redwood 
 Adding a provider example is a simple three step process:
 
 1. Create a provider component in `web/src/components`
+  - Make sure to export the client as well
 2. Add the provider logo to `web/src/lib/images`
-3. Add the provider name, slug, photo, and component to `web/src/lib/providers.js`
+3. Add the provider name, slug, photo, client, and component to `web/src/lib/providers.js`

--- a/web/src/components/Auth0/Auth0.js
+++ b/web/src/components/Auth0/Auth0.js
@@ -4,7 +4,7 @@ import { RedwoodApolloProvider } from '@redwoodjs/web/dist/apollo'
 
 import UserTools from '../UserTools/UserTools'
 
-const auth0 = new Auth0Client({
+export const auth0Client = new Auth0Client({
   domain: process.env.AUTH0_DOMAIN,
   client_id: process.env.AUTH0_CLIENT_ID,
   redirect_uri: window.location.href,
@@ -21,7 +21,7 @@ const auth0 = new Auth0Client({
 
 export default (props) => {
   return (
-    <AuthProvider client={auth0} type="auth0" {...props}>
+    <AuthProvider client={auth0Client} type="auth0" {...props}>
       {/* Add apollo provider here, so that useAuth gets passed in for Cells,etc.  */}
       <RedwoodApolloProvider>
         <UserTools

--- a/web/src/components/AuthPing/AuthPing.js
+++ b/web/src/components/AuthPing/AuthPing.js
@@ -1,0 +1,20 @@
+import { useAuth } from '@redwoodjs/auth'
+
+const AuthPing = () => {
+  const { isAuthenticated } = useAuth()
+  const sharedClasses =
+    'bg-green-400 absolute top-0 right-0 mt-2 mr-2 w-2 h-2 rounded-full'
+
+  return (
+    <>
+      {isAuthenticated && (
+        <>
+          <div className={`${sharedClasses} z-10`} />
+          <div className={`${sharedClasses} animate-ping z-0 opacity-75`} />
+        </>
+      )}
+    </>
+  )
+}
+
+export default AuthPing

--- a/web/src/components/AzureActiveDirectory/AzureActiveDirectory.js
+++ b/web/src/components/AzureActiveDirectory/AzureActiveDirectory.js
@@ -5,7 +5,7 @@ import UserTools from '../UserTools/UserTools'
 
 //import PollCurrentVersionCell from 'src/components/PollCurrentVersionCell'
 
-const azureActiveDirectoryClient = new UserAgentApplication({
+export const azureActiveDirectoryClient = new UserAgentApplication({
   auth: {
     clientId: process.env.AZURE_ACTIVE_DIRECTORY_CLIENT_ID,
     authority: process.env.AZURE_ACTIVE_DIRECTORY_AUTHORITY,

--- a/web/src/components/Firebase/Firebase.js
+++ b/web/src/components/Firebase/Firebase.js
@@ -13,7 +13,7 @@ const firebaseClientConfig = {
   appId: process.env.FIREBASE_APP_ID,
 }
 
-const firebaseClient = ((config) => {
+export const firebaseClient = ((config) => {
   firebase.initializeApp(config)
   return firebase
 })(firebaseClientConfig)

--- a/web/src/components/MagicLink/MagicLink.js
+++ b/web/src/components/MagicLink/MagicLink.js
@@ -7,7 +7,7 @@ import AuthResults from 'src/components/AuthResults'
 import PollCurrentVersionCell from 'src/components/PollCurrentVersionCell'
 import Badge from 'src/components/Badge'
 
-const m = new Magic(process.env.MAGICLINK_PUBLIC)
+export const magicLinkClient = new Magic(process.env.MAGICLINK_PUBLIC)
 
 const MagicLinkUserTools = () => {
   const [email, setEmail] = useState('')
@@ -61,7 +61,7 @@ const MagicLinkUserTools = () => {
 
 export default () => {
   return (
-    <AuthProvider client={m} type="magicLink">
+    <AuthProvider client={magicLinkClient} type="magicLink">
       {/* Add apollo provider here, so that useAuth gets passed in for Cells,etc.  */}
       <RedwoodApolloProvider>
         <MagicLinkUserTools />

--- a/web/src/components/Supabase/Supabase.js
+++ b/web/src/components/Supabase/Supabase.js
@@ -7,7 +7,7 @@ import PollCurrentVersionCell from 'src/components/PollCurrentVersionCell'
 import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
 import Badge from 'src/components/Badge'
 
-const supabase = createClient(
+export const supabaseClient = createClient(
   process.env.SUPABASE_URL,
   process.env.SUPABASE_KEY
 )
@@ -92,7 +92,7 @@ const SupabaseUserTools = () => {
 
 export default () => {
   return (
-    <AuthProvider client={supabase} type="supabase">
+    <AuthProvider client={supabaseClient} type="supabase">
       {/* Add apollo provider here, so that useAuth gets passed in for Cells,etc.  */}
       <RedwoodApolloProvider>
         <SupabaseUserTools />

--- a/web/src/lib/providers.js
+++ b/web/src/lib/providers.js
@@ -1,15 +1,18 @@
 import auth0 from './images/auth0.png'
-import Auth0 from 'src/components/Auth0'
+import Auth0, { auth0Client } from 'src/components/Auth0'
 import azureActiveDirectory from './images/azureactivedirectory.png'
-import AzureActiveDirectory from 'src/components/AzureActiveDirectory'
+import AzureActiveDirectory, {
+  azureActiveDirectoryClient,
+} from 'src/components/AzureActiveDirectory'
 import netlify from './images/netlify.png'
 import Netlify from 'src/components/Netlify'
+import netlifyIdentity from 'netlify-identity-widget'
 import magiclink from './images/magiclink.png'
-import MagicLink from 'src/components/MagicLink'
+import MagicLink, { magicLinkClient } from 'src/components/MagicLink'
 import firebase from './images/firebase.png'
-import Firebase from 'src/components/Firebase'
+import Firebase, { firebaseClient } from 'src/components/Firebase'
 import supabase from './images/supabase.png'
-import Supabase from 'src/components/Supabase'
+import Supabase, { supabaseClient } from 'src/components/Supabase'
 import ethereum from './images/ethereum.png'
 import nhost from './images/nhost.png'
 
@@ -18,36 +21,42 @@ export const providers = [
     name: 'Auth0',
     slug: 'auth0',
     image: auth0,
+    client: auth0Client,
     component: <Auth0 />,
   },
   {
     name: 'Azure Active Directory',
     slug: 'azureActiveDirectory',
     image: azureActiveDirectory,
+    client: azureActiveDirectoryClient,
     component: <AzureActiveDirectory />,
   },
   {
     name: 'Netlify',
     slug: 'netlify',
     image: netlify,
+    client: netlifyIdentity,
     component: <Netlify />,
   },
   {
     name: 'MagicLink',
     slug: 'magicLink',
     image: magiclink,
+    client: magicLinkClient,
     component: <MagicLink />,
   },
   {
     name: 'Firebase',
     slug: 'firebase',
     image: firebase,
+    client: firebaseClient,
     component: <Firebase />,
   },
   {
     name: 'Supabase',
     slug: 'supabase',
     image: supabase,
+    client: supabaseClient,
     component: <Supabase />,
   },
   {

--- a/web/src/pages/HomePage/HomePage.js
+++ b/web/src/pages/HomePage/HomePage.js
@@ -1,7 +1,7 @@
 import { Link, routes } from '@redwoodjs/router'
 import { AuthProvider } from '@redwoodjs/auth'
 import { providers } from 'src/lib/providers'
-import Badge from 'src/components/Badge'
+import AuthPing from 'src/components/AuthPing'
 
 const HomePage = () => {
   return (
@@ -11,13 +11,11 @@ const HomePage = () => {
           <Link
             key={i}
             to={routes.provider({ provider: provider.slug })}
-            className="relative col-span-1 flex items-center justify-center py-12 px-8 bg-white border border-red-300 rounded-md transition-colors duration-200 hover:bg-red-100"
+            className="relative col-span-1 flex items-center justify-center py-8 px-8 bg-white border border-red-300 rounded-md transition-colors duration-200 hover:bg-red-100"
           >
             {provider.client && (
               <AuthProvider client={provider.client} type={provider.slug}>
-                <div className="absolute top-0 right-0 mt-2 mr-2">
-                  <Badge />
-                </div>
+                <AuthPing />
               </AuthProvider>
             )}
             <img

--- a/web/src/pages/HomePage/HomePage.js
+++ b/web/src/pages/HomePage/HomePage.js
@@ -1,5 +1,7 @@
 import { Link, routes } from '@redwoodjs/router'
+import { AuthProvider } from '@redwoodjs/auth'
 import { providers } from 'src/lib/providers'
+import Badge from 'src/components/Badge'
 
 const HomePage = () => {
   return (
@@ -9,8 +11,15 @@ const HomePage = () => {
           <Link
             key={i}
             to={routes.provider({ provider: provider.slug })}
-            className="col-span-1 flex items-center justify-center py-8 px-8 bg-white border border-red-300 rounded-md transition-colors duration-200 hover:bg-red-100"
+            className="relative col-span-1 flex items-center justify-center py-12 px-8 bg-white border border-red-300 rounded-md transition-colors duration-200 hover:bg-red-100"
           >
+            {provider.client && (
+              <AuthProvider client={provider.client} type={provider.slug}>
+                <div className="absolute top-0 right-0 mt-2 mr-2">
+                  <Badge />
+                </div>
+              </AuthProvider>
+            )}
             <img
               className="max-h-10 max-w-24 h-auto w-auto"
               src={provider.image}


### PR DESCRIPTION
# Overview

Adds the Authenticated/Not Authenticated badge to each provider on the homepage logo cloud. This shows the auth status of each provider.

- Requires client to be exported from the provider component and added to the data in `web/src/lib/providers.js`
- Only shows if a client is provided
- Updates CONTRIBUTING to include the client

Closes #35 

## Notes

Please test this a few times before merging to ensure proper functionality. I was not sure if exporting the individual client would work but it seems to.

## Screenshot

![image](https://user-images.githubusercontent.com/10109983/115160620-28b5a280-a067-11eb-9d22-af310460940b.png)
