### PR TITLE
Update results presentation

### DIFF
--- a/web/src/components/AuthResults/AuthResults.js
+++ b/web/src/components/AuthResults/AuthResults.js
@@ -1,5 +1,6 @@
 import { useAuth } from '@redwoodjs/auth'
 import { useEffect, useState } from 'react'
+import Modal from 'src/components/Modal'
 
 export default () => {
   const { type, userMetadata, currentUser, isAuthenticated } = useAuth()
@@ -8,34 +9,56 @@ export default () => {
   const tokenOk = currentUser?.token && currentUser?.token !== 'null'
 
   const [lastUpdate, setLastUpdate] = useState('lastUpdate')
+  const [modalOpen, setModalOpen] = useState(false)
 
   useEffect(() => {
     setLastUpdate(new Date().toLocaleTimeString())
   }, [currentUser, userMetadata, isAuthenticated])
 
   return (
-    <div className="w-full overflow-x-auto overflow-y-auto text-sm max-h-80">
-      <p>Last update {lastUpdate}</p>
-      <code>
-        userMetaData:
-        <pre style={{ margin: 0 }}>{JSON.stringify(userMetadata, null, 2)}</pre>
-      </code>
-      <br />
-      <code>
-        currentUser:
-        <pre style={{ margin: 0 }}>{JSON.stringify(currentUser, null, 2)}</pre>
-      </code>
+    <>
+      <button className="btn btn-alt" onClick={() => setModalOpen(true)}>
+        Auth Results
+      </button>
+      <Modal
+        title={'Authentication Results'}
+        open={modalOpen}
+        setOpen={setModalOpen}
+      >
+        <div className="w-full overflow-x-auto overflow-y-auto text-sm max-h-80">
+          <p>Last update {lastUpdate}</p>
+          <code>
+            userMetaData:
+            <pre style={{ margin: 0 }}>
+              {JSON.stringify(userMetadata, null, 2)}
+            </pre>
+          </code>
+          <br />
+          <code>
+            currentUser:
+            <pre style={{ margin: 0 }}>
+              {JSON.stringify(currentUser, null, 2)}
+            </pre>
+          </code>
 
-      {isAuthenticated ? (
-        <>
-          <h3>Basic sanity checks</h3>
-          <ul>
-            <li style={{ color: typeOk ? 'green' : 'red' }}>Correct type</li>
-            <li style={{ color: emailOk ? 'green' : 'red' }}>Valid email</li>
-            <li style={{ color: tokenOk ? 'green' : 'red' }}>Token !== null</li>
-          </ul>
-        </>
-      ) : null}
-    </div>
+          {isAuthenticated ? (
+            <>
+              <h3>Basic sanity checks</h3>
+              <ul>
+                <li style={{ color: typeOk ? 'green' : 'red' }}>
+                  Correct type
+                </li>
+                <li style={{ color: emailOk ? 'green' : 'red' }}>
+                  Valid email
+                </li>
+                <li style={{ color: tokenOk ? 'green' : 'red' }}>
+                  Token !== null
+                </li>
+              </ul>
+            </>
+          ) : null}
+        </div>
+      </Modal>
+    </>
   )
 }

--- a/web/src/components/Firebase/Firebase.js
+++ b/web/src/components/Firebase/Firebase.js
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import AuthResults from 'src/components/AuthResults'
 import LogInOutButtons from 'src/components/LogInOutButtons/LogInOutButtons'
 import Badge from 'src/components/Badge'
+import ProviderData from 'src/components/ProviderData'
 
 const firebaseClientConfig = {
   apiKey: process.env.FIREBASE_API_KEY,
@@ -95,8 +96,7 @@ const FirebaseUserTools = () => {
           )}
         </>
       )}
-      <br />
-      <AuthResults />
+      <ProviderData />
     </div>
   )
 }

--- a/web/src/components/MagicLink/MagicLink.js
+++ b/web/src/components/MagicLink/MagicLink.js
@@ -3,9 +3,8 @@ import { RedwoodApolloProvider } from '@redwoodjs/web/dist/apollo'
 import { Magic } from 'magic-sdk'
 import { useState } from 'react'
 
-import AuthResults from 'src/components/AuthResults'
-import PollCurrentVersionCell from 'src/components/PollCurrentVersionCell'
 import Badge from 'src/components/Badge'
+import ProviderData from 'src/components/ProviderData'
 
 export const magicLinkClient = new Magic(process.env.MAGICLINK_PUBLIC)
 
@@ -17,7 +16,6 @@ const MagicLinkUserTools = () => {
   return (
     <div>
       <Badge />
-      {isAuthenticated && <PollCurrentVersionCell />}
       <form action="#">
         <input
           type="email"
@@ -53,8 +51,7 @@ const MagicLinkUserTools = () => {
           </button>
         )}
       </form>
-      <br />
-      <AuthResults />
+      <ProviderData />
     </div>
   )
 }

--- a/web/src/components/Modal/Modal.js
+++ b/web/src/components/Modal/Modal.js
@@ -1,0 +1,68 @@
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment, useRef } from 'react'
+
+const Modal = ({ title, open, setOpen, children }) => {
+  const cancelButtonRef = useRef()
+
+  function closeModal() {
+    setOpen(false)
+  }
+
+  return (
+    <Transition show={open} as={Fragment}>
+      <Dialog
+        as="div"
+        id="modal"
+        className="fixed inset-0 z-50 p-4 overflow-y-auto bg-red-100 bg-opacity-95"
+        initialFocus={cancelButtonRef}
+        static
+        open={open}
+        onClose={closeModal}
+      >
+        <div className="min-h-screen flex items-center justify-center">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Dialog.Overlay className="fixed inset-0" />
+          </Transition.Child>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+              {title && (
+                <Dialog.Title
+                  as="h3"
+                  className="text-lg font-medium mb-4 leading-6 text-gray-900"
+                >
+                  {title}
+                </Dialog.Title>
+              )}
+
+              <div>{children}</div>
+
+              <div className="mt-4">
+                <button type="button" className="btn" onClick={closeModal}>
+                  Got it, thanks!
+                </button>
+              </div>
+            </div>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}
+
+export default Modal

--- a/web/src/components/PollCurrentVersionCell/PollCurrentVersionCell.js
+++ b/web/src/components/PollCurrentVersionCell/PollCurrentVersionCell.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import Modal from 'src/components/Modal'
 
 export const QUERY = gql`
   query PollCurrentVersionQuery {
@@ -28,18 +29,30 @@ export const Failure = ({ error }) => (
 
 export const Success = ({ redwood }) => {
   const [lastUpdate, setLastUpdate] = useState('lastUpdate')
+  const [modalOpen, setModalOpen] = useState(false)
 
   useEffect(() => {
     setLastUpdate(new Date().toLocaleTimeString())
   }, [redwood])
 
   return (
-    <div className="w-full overflow-x-auto overflow-y-auto text-sm max-h-80">
-      <h3>Polling output</h3>
-      <p>Last Changed {lastUpdate}</p>
-      <pre className="text-green-700 w-1/2">
-        {JSON.stringify(redwood, null, 2)}
-      </pre>
-    </div>
+    <>
+      <button className="btn btn-alt" onClick={() => setModalOpen(true)}>
+        Refresh Token Status
+      </button>
+      <Modal
+        title={'Refresh Token Status'}
+        open={modalOpen}
+        setOpen={setModalOpen}
+      >
+        <div className="w-full overflow-x-auto overflow-y-auto text-sm max-h-80">
+          <h3>Polling output</h3>
+          <p>Last Changed {lastUpdate}</p>
+          <pre className="text-green-700 w-1/2">
+            {JSON.stringify(redwood, null, 2)}
+          </pre>
+        </div>
+      </Modal>
+    </>
   )
 }

--- a/web/src/components/ProviderData/ProviderData.js
+++ b/web/src/components/ProviderData/ProviderData.js
@@ -1,0 +1,16 @@
+import { useAuth } from '@redwoodjs/auth'
+import AuthResults from 'src/components/AuthResults'
+import PollCurrentVersionCell from 'src/components/PollCurrentVersionCell'
+
+const ProviderData = () => {
+  const { isAuthenticated } = useAuth()
+
+  return (
+    <div className="flex gap-2 mt-8 pt-8 border-t border-red-300">
+      <AuthResults />
+      {isAuthenticated && <PollCurrentVersionCell />}
+    </div>
+  )
+}
+
+export default ProviderData

--- a/web/src/components/Supabase/Supabase.js
+++ b/web/src/components/Supabase/Supabase.js
@@ -2,10 +2,9 @@ import { AuthProvider, useAuth } from '@redwoodjs/auth'
 import { createClient } from '@supabase/supabase-js'
 import { useState } from 'react'
 
-import AuthResults from 'src/components/AuthResults'
-import PollCurrentVersionCell from 'src/components/PollCurrentVersionCell'
 import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
 import Badge from 'src/components/Badge'
+import ProviderData from 'src/components/ProviderData'
 
 export const supabaseClient = createClient(
   process.env.SUPABASE_URL,
@@ -26,7 +25,6 @@ const SupabaseUserTools = () => {
   return (
     <div>
       <Badge />
-      {isAuthenticated && <PollCurrentVersionCell />}
       <form>
         <input
           type="email"
@@ -84,8 +82,7 @@ const SupabaseUserTools = () => {
           Sign Up
         </button>
       )}
-      <br />
-      <AuthResults />
+      <ProviderData />
     </div>
   )
 }

--- a/web/src/components/UserTools/UserTools.js
+++ b/web/src/components/UserTools/UserTools.js
@@ -1,15 +1,14 @@
 import { useAuth } from '@redwoodjs/auth'
-import AuthResults from 'src/components/AuthResults'
-import PollCurrentVersionCell from 'src/components/PollCurrentVersionCell'
 import LogInOutButtons from '../LogInOutButtons/LogInOutButtons'
 import Badge from 'src/components/Badge'
+import ProviderData from 'src/components/ProviderData'
 
 const UserTools = ({
   logInOptions = {},
   logOutOptions = {},
   signUpOptions = {},
 }) => {
-  const { isAuthenticated, loading } = useAuth()
+  const { loading } = useAuth()
 
   if (loading) {
     return 'Loading...'
@@ -18,14 +17,12 @@ const UserTools = ({
   return (
     <div>
       <Badge />
-      {isAuthenticated && <PollCurrentVersionCell />}
       <LogInOutButtons
         logInOptions={logInOptions}
         logOutOptions={logOutOptions}
         signUpOptions={signUpOptions}
       />
-      <br />
-      <AuthResults />
+      <ProviderData />
     </div>
   )
 }


### PR DESCRIPTION
# Overview

Puts the Auth Results and Refresh Token Status into modals. This is a PR to start forming ideas from #51 

Closes #51 

- Adds Modal component ([HeadlessUI Dialog](https://headlessui.dev/react/dialog)) that can be reused throughout the app
- Wraps AuthResults and PollCurrentProvider components in Modals
- Creates a component with both components that can be dropped into each provider

## Notes

From @dthyresson [here](https://github.com/redwoodjs/playground-auth/issues/51#issuecomment-824050760):
> @dac09 makes a good point - with the modal hidden, it won't show the status info if there is a problem readily. Unless the button caption informs you of the problem.

The way the Modals are added to the components it has the button included as well so we could perhaps have an indicator on those.

It looks like there might be an error with Firebase in this format. Perhaps there are issues with others but definitely needs more finesse.

## Screenshots

![image](https://user-images.githubusercontent.com/10109983/115584502-d22faa80-a298-11eb-80c1-b459c73b5a68.png)

![image](https://user-images.githubusercontent.com/10109983/115584522-d5c33180-a298-11eb-87c2-05f5bfc8a558.png)
