### PR TITLE
fix(prisma): RW toml specifies schema location

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -23,8 +23,8 @@
     'SUPABASE_JWT_SECRET',
     'NHOST_BACKEND_URL'
   ]
-
 [api]
   port = 8911
+  schemaPath = "./api/db/schema.prisma"
 [browser]
   open = true


### PR DESCRIPTION
The RW toml was missing the schema path having upgraded from a mid/early v.2x release to v.31 and moving the schema to the current v31 expected location.

```
[api]
  port = 8911
  schemaPath = "./api/db/schema.prisma"
```

This PR corrects that and thus fixes a build error when deploying to Netlify:

```terminal
12:48:57 PM: $ /opt/build/repo/node_modules/.bin/rw prisma migrate deploy
12:49:00 PM: 
12:49:00 PM:  Cannot run command. No Prisma Schema found.
12:49:00 PM: 
12:49:00 PM: error Command failed with exit code 1.
```