### PR TITLE
Adds Supabase example code for auth state changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@redwoodjs/core": "^0.41.0",
-    "lodash-decorators": "^6.0.1"
+    "lodash-decorators": "6.0.1"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config"

--- a/web/src/components/Supabase/Supabase.js
+++ b/web/src/components/Supabase/Supabase.js
@@ -67,7 +67,7 @@ const SupabaseUserTools = () => {
 
     if (event === 'SIGNED_OUT') {
       console.debug('>> in onAuthStateChange', event)
-      // rest auth state to ensure no longer authenticated
+      // reset the auth state to ensure no longer authenticated in all tabs
       await reauthenticate()
     }
 

--- a/web/src/lib/code-samples/supabase.md
+++ b/web/src/lib/code-samples/supabase.md
@@ -6,7 +6,24 @@ const Supabase = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
 
-  const { logIn, logOut, signUp, isAuthenticated } = useAuth()
+  const { client, logIn, logOut, signUp, isAuthenticated, reauthenticate } = useAuth()
+
+  // Here you can subscribe to events
+  client.auth.onAuthStateChange(async (event) => {
+    if (event === 'SIGNED_IN') {
+      console.debug('>> in onAuthStateChange', event)
+    }
+
+    if (event === 'SIGNED_OUT') {
+      console.debug('>> in onAuthStateChange', event)
+      // reset the auth state to ensure no longer authenticated in all tabs
+      await reauthenticate()
+    }
+
+    if (event === 'TOKEN_REFRESHED') {
+      console.debug('>> in onAuthStateChange', event)
+    }
+  })
 
   const resetForm = () => {
     setEmail('')


### PR DESCRIPTION
This PR adds the example code to subscribe and listen for auth state change events.

One can then reauthenticate when signed out in multiple tabs -- or do "some work" on other changes, like signing in or when your token is refreshed.